### PR TITLE
Add in bash path

### DIFF
--- a/Classic-Resource-Finder.sh
+++ b/Classic-Resource-Finder.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 #
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0


### PR DESCRIPTION
*Issue #, if available:*

Error running on Ubuntu, `./Classic-Resource-Finder.sh: 28: [[: not found`

*Description of changes:*

Added in a bash path. This avoids an error of: 

```
~ ./Classic-Resource-Finder.sh 
./Classic-Resource-Finder.sh: 28: [[: not found
./Classic-Resource-Finder.sh: 1: Syntax error: redirection unexpected
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
