### PR TITLE
Limit ElasticBeanstalk to 'Ready' Environments

### DIFF
--- a/Classic-Resource-Finder.sh
+++ b/Classic-Resource-Finder.sh
@@ -211,7 +211,7 @@ do
         fi
         ebappnext=`jq -r '.NextToken' <<< $ebappraw 2> /dev/null` ## Use JQ to parse the NextToken and store it in a variable
         IFS=$'\n' ## Set our internal field seperator to newline so we ignore the space delimiter in the for loop
-        for ebenvapp in `jq -r '.Environments[] | .ApplicationName +" "+ .EnvironmentName' <<< $ebappraw 2> /dev/null` ## Loop over each application and environment pair
+        for ebenvapp in `jq -r '.Environments[]|select(.Status == "Ready") | .ApplicationName +" "+ .EnvironmentName' <<< $ebappraw 2> /dev/null` ## Loop over each application and environment pair
             do
             ebapp=`cut -d " " -f1 <<< $ebenvapp 2> /dev/null` ## Extract the Application name
             ebenv=`cut -d " " -f2 <<< $ebenvapp 2> /dev/null` ## Extract the Environment name


### PR DESCRIPTION
Address the [issue][1] wherein 'Terminated' Environments are being reported
as Classic EC2 resources that need to be addressed.  Which is not true.
This commit filters on those resources that are 'Ready' so that if they
have Classic EC2 resources they will be properly reported.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.

[1]:  https://github.com/aws-samples/ec2-classic-resource-finder/issues/3

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
