### PR TITLE
Fix Markdown hyperlink syntax for AWS CLI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This script helps identify all resources provisioned in EC2-Classic across all r
  
 ## Requirements
  
-This script is designed to run in Bash and requires the [AWS CLI] (https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html), JQ, and the linux Cut utility. The CLI must either be already authenticated either via an IAM role, AWS SSO or an IAM access key with appropriate permissions as outlined below.
+This script is designed to run in Bash and requires the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html), JQ, and the linux Cut utility. The CLI must either be already authenticated either via an IAM role, AWS SSO or an IAM access key with appropriate permissions as outlined below.
  
 ### For Mac
  


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Minor: Fixed a typo in the README; the Markdown hyperlink syntax for the AWS CLI was incorrect.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
